### PR TITLE
Restructure folder structure for tests #80

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -35,6 +35,8 @@ const customJestConfig = {
     '<rootDir>/src/**/__tests__/**/*.{js,jsx,ts,tsx}',
     '<rootDir>/src/**/*.(test|spec).{js,jsx,ts,tsx}',
     '<rootDir>/tests/**/*.{js,jsx,ts,tsx}',
+    '<rootDir>/tests/unit/**/*.{js,jsx,ts,tsx}',
+    '<rootDir>/tests/integration/**/*.{js,jsx,ts,tsx}',
   ],
 
   // Files to ignore
@@ -45,8 +47,8 @@ const customJestConfig = {
     '<rootDir>/dist/',
   ],
 
-  // Coverage configuration
-  collectCoverage: true,
+  // Coverage configuration - only collect coverage in CI to keep local runs fast
+  collectCoverage: !!process.env.CI,
   coverageDirectory: 'coverage',
   coverageReporters: ['text', 'lcov', 'html'],
 

--- a/tests/integration/app/add-listing/page.test.js
+++ b/tests/integration/app/add-listing/page.test.js
@@ -9,9 +9,9 @@
 // src/app/add-listing/__tests__/page.test.js
 import { render, screen, fireEvent } from '@testing-library/react';
 import { redirect } from 'next/navigation';
-import AddListingPage from '../page';
-import { uploadListingAction } from '../actions';
-import { uploadImageToS3 } from '../../../lib/awss3';
+import AddListingPage from '@/app/add-listing/page';
+import { uploadListingAction } from '@/app/add-listing/actions';
+import { uploadImageToS3 } from '@/lib/awss3';
 
 // Mocked MongoDB client to simulate in-memory inserts and queries
 const mockCollection = {
@@ -24,7 +24,7 @@ const mockClient = {
   db: jest.fn(() => mockDb),
 };
 
-jest.mock('../../../lib/mongodb', () => ({
+jest.mock('@/lib/mongodb', () => ({
   default: Promise.resolve(mockClient),
   getDb: jest.fn((dbName) => {
     const name = dbName || process.env.MONGODB_DB || 'TinyThreads';
@@ -41,7 +41,7 @@ jest.mock('next/navigation', () => ({
 }));
 
 // Mocked AWS S3 helper to prevent real network requests
-jest.mock('../../../lib/awss3', () => ({
+jest.mock('@/lib/awss3', () => ({
   uploadImageToS3: jest.fn(),
 }));
 

--- a/tests/integration/app/layout.test.js
+++ b/tests/integration/app/layout.test.js
@@ -8,9 +8,9 @@ jest.mock('next/font/google', () => ({
 }));
 
 // Mock CSS import
-jest.mock('../globals.css', () => ({}));
+jest.mock('@/app/globals.css', () => ({}));
 
-import RootLayout, { metadata } from '../layout';
+import RootLayout, { metadata } from '@/app/layout';
 import { Geist, Geist_Mono } from 'next/font/google';
 
 // Get the mocked functions

--- a/tests/integration/app/page.test.js
+++ b/tests/integration/app/page.test.js
@@ -6,7 +6,7 @@ import {
   act,
 } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import BrowsePage from '../page';
+import BrowsePage from '@/app/page';
 import { getItems, filterItems } from '@/services/itemService';
 
 // Mock Next.js Link component
@@ -74,7 +74,7 @@ jest.mock('@/components/ItemGrid/ItemGrid', () => {
 });
 
 // Mock CSS modules
-jest.mock('../page.module.css', () => ({
+jest.mock('@/app/page.module.css', () => ({
   page: 'page',
   container: 'container',
   headerSection: 'headerSection',

--- a/tests/unit/components/FilterBar.test.js
+++ b/tests/unit/components/FilterBar.test.js
@@ -1,6 +1,5 @@
-// src/components/__tests__/FilterBar.test.js
 import { render, screen, fireEvent } from '@testing-library/react';
-import FilterBar from '../FilterBar/FilterBar';
+import FilterBar from '@/components/FilterBar/FilterBar';
 
 describe('FilterBar Component', () => {
   const mockOnFiltersChange = jest.fn();

--- a/tests/unit/components/ItemCard.test.js
+++ b/tests/unit/components/ItemCard.test.js
@@ -1,7 +1,6 @@
-// src/components/__tests__/ItemCard.test.js
 import { render, screen, fireEvent } from '@testing-library/react';
 import { useRouter } from 'next/navigation';
-import ItemCard from '../ItemCard/ItemCard';
+import ItemCard from '@/components/ItemCard/ItemCard';
 
 // Mock Next.js Image component (FIXED VERSION)
 jest.mock('next/image', () => {

--- a/tests/unit/components/ItemDetail.test.js
+++ b/tests/unit/components/ItemDetail.test.js
@@ -6,8 +6,8 @@ import {
   act,
 } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import ItemDetail from '../ItemDetail/ItemDetail'; // Import current version, not ItemDetail 2
-import { getItemById } from '../../services/itemService'; // Current version uses getItemById
+import ItemDetail from '@/components/ItemDetail/ItemDetail'; // Import current version, not ItemDetail 2
+import { getItemById } from '@/services/itemService'; // Current version uses getItemById
 import { useRouter } from 'next/navigation';
 
 // Mock Next.js router
@@ -34,12 +34,12 @@ jest.mock('next/image', () => ({
 }));
 
 // Mock itemService - current version uses getItemById
-jest.mock('../../services/itemService', () => ({
+jest.mock('@/services/itemService', () => ({
   getItemById: jest.fn(),
 }));
 
 // Mock CSS modules
-jest.mock('../ItemDetail/ItemDetail.module.css', () => ({
+jest.mock('@/components/ItemDetail/ItemDetail.module.css', () => ({
   loading: 'loading',
   loadingSpinner: 'loadingSpinner',
   notFound: 'notFound',

--- a/tests/unit/components/ItemGrid.test.js
+++ b/tests/unit/components/ItemGrid.test.js
@@ -1,5 +1,3 @@
-// src/components/__tests__/ItemGrid.test.js
-
 import {
   render,
   screen,
@@ -7,10 +5,10 @@ import {
   waitFor,
   act,
 } from '@testing-library/react';
-import ItemGrid from '../ItemGrid/ItemGrid';
+import ItemGrid from '@/components/ItemGrid/ItemGrid';
 
 // Mock ItemCard component
-jest.mock('../ItemCard/ItemCard', () => {
+jest.mock('@/components/ItemCard/ItemCard', () => {
   return function MockItemCard({ item }) {
     return (
       <div data-testid={`item-card-${item.id}`}>

--- a/tests/unit/components/Navbar.test.js
+++ b/tests/unit/components/Navbar.test.js
@@ -1,5 +1,5 @@
 // Mock CSS modules
-jest.mock('../Navbar/Navbar.module.css', () => ({
+jest.mock('@/components/Navbar/Navbar.module.css', () => ({
   navbar: 'navbar',
   brandWrapper: 'brandWrapper',
   brand: 'brand',
@@ -29,8 +29,8 @@ jest.mock('next/image', () => {
 
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import Navbar from '../Navbar/Navbar';
-jest.mock('../Navbar/Navbar.module.css', () => ({
+import Navbar from '@/components/Navbar/Navbar';
+jest.mock('@/components/Navbar/Navbar.module.css', () => ({
   navbar: 'navbar',
   brandWrapper: 'brandWrapper',
   brand: 'brand',

--- a/tests/unit/lib/awss3.test.js
+++ b/tests/unit/lib/awss3.test.js
@@ -51,7 +51,7 @@ describe('awss3', () => {
       delete process.env.AWS_REGION;
 
       await expect(async () => {
-        await import('../awss3.js');
+        await import('@/lib/awss3.js');
       }).rejects.toThrow(
         'Missing AWS credentials or region in environment variables',
       );
@@ -61,7 +61,7 @@ describe('awss3', () => {
       delete process.env.AWS_ACCESS_KEY_ID;
 
       await expect(async () => {
-        await import('../awss3.js');
+        await import('@/lib/awss3.js');
       }).rejects.toThrow(
         'Missing AWS credentials or region in environment variables',
       );
@@ -71,7 +71,7 @@ describe('awss3', () => {
       delete process.env.AWS_SECRET_ACCESS_KEY;
 
       await expect(async () => {
-        await import('../awss3.js');
+        await import('@/lib/awss3.js');
       }).rejects.toThrow(
         'Missing AWS credentials or region in environment variables',
       );
@@ -81,13 +81,13 @@ describe('awss3', () => {
       delete process.env.S3_BUCKET_NAME;
 
       await expect(async () => {
-        await import('../awss3.js');
+        await import('@/lib/awss3.js');
       }).rejects.toThrow('Missing S3_BUCKET_NAME in environment variables');
     });
 
     test('initializes S3Client with correct configuration when all env vars present', async () => {
       // Import with valid environment
-      await import('../awss3.js');
+      await import('@/lib/awss3.js');
 
       expect(mockS3Client).toHaveBeenCalledWith({
         region: 'us-east-1',
@@ -104,7 +104,7 @@ describe('awss3', () => {
     let getPublicUrl;
 
     beforeEach(async () => {
-      const awsModule = await import('../awss3.js');
+      const awsModule = await import('@/lib/awss3.js');
       getPublicUrl = awsModule.getPublicUrl;
     });
 
@@ -147,7 +147,7 @@ describe('awss3', () => {
       mockRandomUUID.mockReturnValue('12345678-1234-5678-9012-123456789abc');
       mockSend.mockResolvedValue({});
 
-      const awsModule = await import('../awss3.js');
+      const awsModule = await import('@/lib/awss3.js');
       uploadImageToS3 = awsModule.uploadImageToS3;
     });
 
@@ -379,7 +379,7 @@ describe('awss3', () => {
       jest.resetModules();
 
       await expect(async () => {
-        await import('../awss3.js');
+        await import('@/lib/awss3.js');
       }).rejects.toThrow('Invalid AWS configuration');
     });
 
@@ -427,7 +427,7 @@ describe('awss3', () => {
   // ===== DEFAULT EXPORT TEST =====
   describe('default export', () => {
     test('exports S3Client instance', async () => {
-      const awsModule = await import('../awss3.js');
+      const awsModule = await import('@/lib/awss3.js');
 
       expect(awsModule.default).toBeDefined();
       // The default export should be the result of new S3Client()

--- a/tests/unit/lib/mongodb.test.js
+++ b/tests/unit/lib/mongodb.test.js
@@ -25,7 +25,7 @@ describe('mongodb helper getDb', () => {
       process.env.MONGODB_URI || 'mongodb://localhost:27017';
 
     // Import the module under test after mocks are set up
-    const { getDb } = await import('../../lib/mongodb.js');
+    const { getDb } = await import('@/lib/mongodb.js');
 
     // Call getDb and assert
     const db = await getDb('custom-db');

--- a/tests/unit/services/itemService.test.js
+++ b/tests/unit/services/itemService.test.js
@@ -1,4 +1,3 @@
-// src/services/__tests__/itemService.test.js
 import {
   getItems,
   getItemById,
@@ -7,10 +6,10 @@ import {
   getItemsBySeller,
   getAvailableFilters,
   getFeaturedItems,
-} from '../itemService';
+} from '@/services/itemService';
 
-// Mock the types/item module
-jest.mock('../../types/item', () => ({
+// Mock the types/item module using the alias so this file works from its new location
+jest.mock('@/types/item', () => ({
   getFilterOptions: jest.fn(() => ({
     categories: ['Clothing', 'Toys', 'Books'],
     conditions: ['New', 'Like New', 'Good', 'Fair'],

--- a/tests/unit/types/item.test.js
+++ b/tests/unit/types/item.test.js
@@ -6,7 +6,7 @@ import {
   validateItem,
   getFilterOptions,
   exampleItem,
-} from '../item';
+} from '@/types/item';
 
 describe('item.js types and utilities', () => {
   // ===== ITEM_CONFIG TESTS =====


### PR DESCRIPTION
This pull request refactors the test suite structure and updates import paths to use absolute aliases, improving maintainability and consistency. It also updates Jest configuration to optimize coverage collection and test file discovery, particularly separating unit and integration tests for clarity and scalability.

**Test organization and import path standardization:**

* All test files have been moved from their previous locations (e.g., `src/components/__tests__`) to new, clearly separated `tests/unit` and `tests/integration` directories, and their import paths have been updated to use the absolute alias (`@/`) for consistency. 

**Jest configuration improvements:**

* Added new test match patterns to discover tests in `tests/unit` and `tests/integration` directories, making it easier to manage and scale test coverage.
* Updated coverage collection to only run in CI environments, which speeds up local test runs while maintaining robust coverage reporting in automated pipelines.

**Mocking and test reliability:**

* Updated all Jest mock paths to use the alias (`@/`) rather than relative paths, reducing the risk of broken imports and making tests more robust across refactors.

**Service and utility test updates:**

* All service and utility tests now import modules using the alias, ensuring consistency and easier future maintenance. 

**Component and page test updates:**

* All component and page tests have been updated to use absolute imports and mocks, improving reliability and alignment with the new test directory structure.
