### PR TITLE
Feature/pagination[#94]

### DIFF
--- a/__mocks__/next/image.js
+++ b/__mocks__/next/image.js
@@ -1,7 +1,18 @@
-/* eslint-disable @next/next/no-img-element */
-/* eslint-disable jsx-a11y/alt-text */
+import React from 'react';
 
-// Mock for next/image to work inside Jest tests
+// Safe Jest mock for `next/image`.
+// Only forwards safe DOM props so React doesn't warn during tests.
 export default function Image(props) {
-  return <img {...props} />;
+  const { src, alt, width, height, className, style } = props || {};
+
+  const safeProps = {};
+  if (src !== undefined)
+    safeProps.src = typeof src === 'string' ? src : String(src);
+  if (alt !== undefined) safeProps.alt = alt;
+  if (className) safeProps.className = className;
+  if (width !== undefined) safeProps.width = width;
+  if (height !== undefined) safeProps.height = height;
+  if (style) safeProps.style = style;
+
+  return React.createElement('img', safeProps);
 }

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -28,6 +28,8 @@ const customJestConfig = {
     // Handle absolute imports from src/
     '^@/(.*)$': '<rootDir>/src/$1',
     '^~/(.*)$': '<rootDir>/src/$1',
+    // Map next/image to our Jest mock to avoid forwarding next/image props to the DOM
+    '^next/image$': '<rootDir>/__mocks__/next/image.js',
   },
 
   // Test file patterns

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import './.next/dev/types/routes.d.ts';
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import './.next/dev/types/routes.d.ts';
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/app/api/items/route.js
+++ b/src/app/api/items/route.js
@@ -60,11 +60,17 @@ export async function GET(req) {
     'price-high': { price: -1 },
   }[sortBy] || { createdAt: -1 };
 
-  const limitValue = Number(searchParams.get('limit')) || 48;
+  const page = Math.max(1, Number(searchParams.get('page')) || 1);
+  const limitValue = Math.max(1, Number(searchParams.get('limit')) || 12);
+  const skip = (page - 1) * limitValue;
+
+  // total matching documents for pagination metadata
+  const total = await collection.countDocuments(query);
 
   const items = await collection
     .find(query)
     .sort(sort)
+    .skip(skip)
     .limit(limitValue)
     .toArray();
 
@@ -73,5 +79,13 @@ export async function GET(req) {
     ...rest,
   }));
 
-  return NextResponse.json({ items: serialized, total: serialized.length });
+  const hasMore = page * limitValue < total;
+
+  return NextResponse.json({
+    items: serialized,
+    total: Number(total),
+    page: Number(page),
+    limit: Number(limitValue),
+    hasMore,
+  });
 }

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -10,7 +10,6 @@ import useItemsPerPage from '@/hooks/useItemsPerPage';
 import Pagination from '@/components/Pagination/Pagination';
 
 export default function BrowsePage() {
-  const [items, setItems] = useState([]);
   const [filteredItems, setFilteredItems] = useState([]);
   const [loading, setLoading] = useState(true);
   const [page, setPage] = useState(1);
@@ -35,9 +34,6 @@ export default function BrowsePage() {
         } else {
           setFilteredItems(data.items);
         }
-        setItems((prevAll) =>
-          append ? [...prevAll, ...data.items] : data.items,
-        );
         setPage(Number(data.page || requestedPage));
         setHasMore(Boolean(data.hasMore));
         setTotal(Number(data.total || 0));

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -1,52 +1,76 @@
 // src/app/page.js
 'use client';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import styles from './page.module.css';
 import Navbar from '@/components/Navbar/Navbar';
 import FilterBar from '@/components/FilterBar/FilterBar';
 import ItemGrid from '@/components/ItemGrid/ItemGrid';
-import { getItems, filterItems } from '@/services/itemService';
+import { getItems /* filterItems */ } from '@/services/itemService';
+import useItemsPerPage from '@/hooks/useItemsPerPage';
+import Pagination from '@/components/Pagination/Pagination';
 
 export default function BrowsePage() {
   const [items, setItems] = useState([]);
   const [filteredItems, setFilteredItems] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [page, setPage] = useState(1);
+  const [hasMore, setHasMore] = useState(false);
+  const [total, setTotal] = useState(0);
   const [filters, setFilters] = useState({});
+  // default rowsPerPage is 3 in the hook (3 rows × 3 columns = 9 items)
+  const itemsPerPage = useItemsPerPage();
 
-  useEffect(() => {
-    const loadItems = async () => {
+  // Load initial page or when filters / page / itemsPerPage change
+  const loadPage = useCallback(
+    async (requestedPage = 1, append = false, currentFilters = filters) => {
       setLoading(true);
       try {
-        const data = await getItems();
-        setItems(data.items);
-        setFilteredItems(data.items);
-        setLoading(false);
+        const data = await getItems(
+          requestedPage,
+          itemsPerPage,
+          currentFilters,
+        );
+        if (append) {
+          setFilteredItems((prev) => [...prev, ...data.items]);
+        } else {
+          setFilteredItems(data.items);
+        }
+        setItems((prevAll) =>
+          append ? [...prevAll, ...data.items] : data.items,
+        );
+        setPage(Number(data.page || requestedPage));
+        setHasMore(Boolean(data.hasMore));
+        setTotal(Number(data.total || 0));
       } catch (error) {
         console.error('Failed to load items:', error);
+      } finally {
         setLoading(false);
       }
-    };
-    loadItems();
-  }, []);
+    },
+    [itemsPerPage, filters],
+  );
 
-  const handleFiltersChange = async (newFilters) => {
+  useEffect(() => {
+    // reset to first page whenever filters or itemsPerPage changes
+    loadPage(1, false, filters);
+  }, [loadPage, filters, itemsPerPage]);
+
+  const handleFiltersChange = (newFilters) => {
     setFilters(newFilters);
-    setLoading(true);
-
-    try {
-      const filtered = await filterItems(newFilters);
-      setFilteredItems(filtered.items);
-      setLoading(false);
-    } catch (error) {
-      console.error('Failed to filter items:', error);
-      setLoading(false);
-    }
+    // loadPage effect will run due to filters dependency
   };
 
   const clearAllFilters = () => {
     const clearedFilters = {};
     setFilters(clearedFilters);
-    setFilteredItems(items);
+    // loadPage effect will reset filtered items
+  };
+
+  // numbered pagination handler
+  const handlePageChange = async (newPage) => {
+    if (!newPage || newPage === page) return;
+    // request the new page and replace items (not append)
+    await loadPage(newPage, false, filters);
   };
 
   // calculate active filters count
@@ -84,7 +108,16 @@ export default function BrowsePage() {
         </section>
 
         {/* Content Section */}
-        <ItemGrid items={filteredItems} loading={loading} hasMore={false} />
+        <ItemGrid items={filteredItems} loading={loading} hasMore={hasMore} />
+
+        <div style={{ display: 'flex', justifyContent: 'center' }}>
+          <Pagination
+            page={page}
+            total={total}
+            limit={itemsPerPage}
+            onPageChange={handlePageChange}
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/components/ItemDetail/ItemDetail.js
+++ b/src/components/ItemDetail/ItemDetail.js
@@ -135,7 +135,9 @@ export default function ItemDetail({ itemId }) {
         try {
           const body = await res.json();
           if (body?.error) message = body.error;
-        } catch (e) {}
+        } catch {
+          // ignore JSON parse errors
+        }
         throw new Error(message);
       }
 

--- a/src/components/ItemDetail/ItemDetail.module.css
+++ b/src/components/ItemDetail/ItemDetail.module.css
@@ -227,7 +227,6 @@
   font-weight: 700;
   font-size: 15px;
   cursor: pointer;
-  box-shadow: 0 8px 20px rgba(242, 123, 101, 0.14);
   transition:
     transform 0.12s ease,
     box-shadow 0.12s ease,

--- a/src/components/ItemGrid/ItemGrid.js
+++ b/src/components/ItemGrid/ItemGrid.js
@@ -89,7 +89,7 @@ export default function ItemGrid({
       </div>
 
       {/* Load More Button */}
-      {hasMore && (
+      {hasMore && onLoadMore && (
         <div className={styles.loadMore}>
           <button
             className={styles.loadMoreButton}

--- a/src/components/ItemGrid/ItemGrid.js
+++ b/src/components/ItemGrid/ItemGrid.js
@@ -2,31 +2,14 @@
 
 // components/ItemGrid/ItemGrid.js
 import styles from './ItemGrid.module.css';
-import { useState } from 'react';
+import React from 'react';
 import ItemCard from '../ItemCard/ItemCard';
 
 export default function ItemGrid({
   items = [],
   loading = false,
   hasMore = true,
-  onLoadMore,
 }) {
-  const [loadingMore, setLoadingMore] = useState(false);
-
-  const handleLoadMore = async () => {
-    if (loadingMore || !hasMore || !onLoadMore) return;
-
-    setLoadingMore(true);
-    try {
-      await onLoadMore();
-    } catch (error) {
-      // Error is handled by the caller, just ensure loading state is reset
-      console.error('Load more failed:', error);
-    } finally {
-      setLoadingMore(false);
-    }
-  };
-
   // Loading skeleton component
   const LoadingSkeleton = () => (
     <div className={styles.skeletonCard}>
@@ -74,39 +57,13 @@ export default function ItemGrid({
 
       {/* Grid */}
       <div className={styles.grid}>
-        {items.map((item) => (
-          <ItemCard key={item.id} item={item} />
+        {items.map((item, idx) => (
+          <ItemCard
+            key={item?.id ?? item?._id ?? item?.slug ?? idx}
+            item={item}
+          />
         ))}
-
-        {/* Loading skeletons while loading more */}
-        {loadingMore && (
-          <>
-            {[...Array(4)].map((_, index) => (
-              <LoadingSkeleton key={`loading-${index}`} />
-            ))}
-          </>
-        )}
       </div>
-
-      {/* Load More Button */}
-      {hasMore && onLoadMore && (
-        <div className={styles.loadMore}>
-          <button
-            className={styles.loadMoreButton}
-            onClick={handleLoadMore}
-            disabled={loadingMore}
-          >
-            {loadingMore ? (
-              <span className={styles.loadingText}>
-                <span className={styles.spinner}></span>
-                Loading more...
-              </span>
-            ) : (
-              'Load More Items'
-            )}
-          </button>
-        </div>
-      )}
 
       {/* End message */}
       {!hasMore && items.length > 0 && (

--- a/src/components/ItemGrid/ItemGrid.module.css
+++ b/src/components/ItemGrid/ItemGrid.module.css
@@ -32,7 +32,8 @@
 /* Grid Layout */
 .grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  /* Force 3 columns for consistent rows/columns layout */
+  grid-template-columns: repeat(3, 1fr);
   gap: 20px;
   padding: 20px 0;
 }
@@ -176,7 +177,8 @@
 /* Responsive Design */
 @media (max-width: 1024px) {
   .grid {
-    grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+    /* Keep 3 columns on tablet/desktop widths */
+    grid-template-columns: repeat(3, 1fr);
     gap: 16px;
   }
 
@@ -187,7 +189,8 @@
 
 @media (max-width: 768px) {
   .grid {
-    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    /* Keep 3 columns on most tablet sizes as requested */
+    grid-template-columns: repeat(3, 1fr);
     gap: 16px;
     padding: 16px 0;
   }

--- a/src/components/Pagination/Pagination.js
+++ b/src/components/Pagination/Pagination.js
@@ -1,0 +1,101 @@
+'use client';
+import React from 'react';
+import styles from './Pagination.module.css';
+
+export default function Pagination({
+  page = 1,
+  total = 0,
+  limit = 12,
+  onPageChange,
+  maxPagesToShow = 7,
+}) {
+  if (!onPageChange) return null;
+
+  const totalPages = Math.max(1, Math.ceil(total / limit));
+  if (totalPages <= 1) return null;
+
+  const half = Math.floor(maxPagesToShow / 2);
+  let start = Math.max(1, page - half);
+  let end = Math.min(totalPages, start + maxPagesToShow - 1);
+  if (end - start + 1 < maxPagesToShow)
+    start = Math.max(1, end - maxPagesToShow + 1);
+
+  const pages = [];
+  for (let p = start; p <= end; p++) pages.push(p);
+
+  return (
+    <nav className={styles.pagination} aria-label="Pagination">
+      <button
+        type="button"
+        className={styles.control}
+        onClick={() => onPageChange(1)}
+        disabled={page === 1}
+        aria-label="First page"
+      >
+        « First
+      </button>
+
+      <button
+        type="button"
+        className={styles.control}
+        onClick={() => onPageChange(Math.max(1, page - 1))}
+        disabled={page === 1}
+        aria-label="Previous page"
+      >
+        ‹ Prev
+      </button>
+
+      {start > 1 && (
+        <button
+          type="button"
+          className={styles.ellipsis}
+          onClick={() => onPageChange(start - 1)}
+        >
+          …
+        </button>
+      )}
+
+      {pages.map((p) => (
+        <button
+          key={p}
+          type="button"
+          onClick={() => onPageChange(p)}
+          aria-current={p === page ? 'page' : undefined}
+          className={p === page ? styles.active : styles.page}
+        >
+          {p}
+        </button>
+      ))}
+
+      {end < totalPages && (
+        <button
+          type="button"
+          className={styles.ellipsis}
+          onClick={() => onPageChange(end + 1)}
+        >
+          …
+        </button>
+      )}
+
+      <button
+        type="button"
+        className={styles.control}
+        onClick={() => onPageChange(Math.min(totalPages, page + 1))}
+        disabled={page === totalPages}
+        aria-label="Next page"
+      >
+        Next ›
+      </button>
+
+      <button
+        type="button"
+        className={styles.control}
+        onClick={() => onPageChange(totalPages)}
+        disabled={page === totalPages}
+        aria-label="Last page"
+      >
+        Last »
+      </button>
+    </nav>
+  );
+}

--- a/src/components/Pagination/Pagination.module.css
+++ b/src/components/Pagination/Pagination.module.css
@@ -1,0 +1,39 @@
+.pagination {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  justify-content: center;
+  margin: 20px 0;
+}
+.control {
+  background: #fff;
+  border: 1px solid #ddd;
+  padding: 6px 10px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+.page {
+  background: #fff;
+  border: 1px solid #eee;
+  padding: 6px 9px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+.active {
+  background: #111;
+  color: #fff;
+  border: 1px solid #111;
+  padding: 6px 9px;
+  border-radius: 6px;
+}
+.ellipsis {
+  background: transparent;
+  border: none;
+  padding: 6px 8px;
+  color: #666;
+}
+.control[disabled],
+.page[disabled] {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/src/hooks/useItemsPerPage.js
+++ b/src/hooks/useItemsPerPage.js
@@ -1,0 +1,35 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+// Hook to compute items-per-page based on viewport width.
+// Returns a number suitable to pass as `limit` for paginated requests
+// or to compute slices on the client.
+export default function useItemsPerPage({ rowsPerPage = 3 } = {}) {
+  // rowsPerPage default = 3 since requirement is 3 rows max
+  const [itemsPerPage, setItemsPerPage] = useState(() => {
+    // default guess for SSR hydration safety
+    return 9; // 3 columns x 3 rows
+  });
+
+  useEffect(() => {
+    function compute() {
+      const w = typeof window !== 'undefined' ? window.innerWidth : 1024;
+      let columns;
+
+      // Enforce 3 columns on most screens, single column on very small screens
+      if (w < 480) columns = 1;
+      else columns = 3;
+
+      // items per page = columns * rowsPerPage, cap to at least 1
+      const ip = Math.max(1, columns * Math.max(1, rowsPerPage));
+      setItemsPerPage(ip);
+    }
+
+    compute();
+    window.addEventListener('resize', compute);
+    return () => window.removeEventListener('resize', compute);
+  }, [rowsPerPage]);
+
+  return itemsPerPage;
+}

--- a/tests/integration/app/add-listing/page.test.js
+++ b/tests/integration/app/add-listing/page.test.js
@@ -522,6 +522,19 @@ describe('Add Listing Page', () => {
 
   // ===== SERVER ACTION TESTS =====  — input validation, S3 upload, and DB persistence
   describe('uploadListingAction', () => {
+    let consoleErrorSpy;
+
+    beforeEach(() => {
+      // Many server-action tests intentionally throw/redirect — silence console.error
+      // inside this describe to avoid noisy test output. Restored in afterEach.
+      consoleErrorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      consoleErrorSpy.mockRestore();
+    });
     let mockFile;
 
     beforeEach(() => {

--- a/tests/integration/app/page.pagination.test.js
+++ b/tests/integration/app/page.pagination.test.js
@@ -1,0 +1,77 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+// Ensure next-auth session is mocked for components that read session
+jest.mock('next-auth/react', () => ({
+  useSession: jest.fn(() => ({ data: null, status: 'unauthenticated' })),
+}));
+
+import BrowsePage from '@/app/page';
+import * as itemService from '@/services/itemService';
+
+jest.mock('@/services/itemService');
+
+describe('BrowsePage pagination integration', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    // resetAllMocks clears mock implementations including next-auth's useSession
+    // restore a working useSession implementation for components that expect it
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const na = require('next-auth/react');
+    if (na && na.useSession && na.useSession.mockImplementation) {
+      na.useSession.mockImplementation(() => ({
+        data: null,
+        status: 'unauthenticated',
+      }));
+    }
+  });
+
+  test('loads first page and navigates to page 2 on pagination click', async () => {
+    // mock getItems to return different pages
+    itemService.getItems.mockImplementation((page, limit) => {
+      const total = 18;
+      const per = limit;
+      const start = (page - 1) * per + 1;
+      const items = Array.from(
+        { length: Math.min(per, total - (page - 1) * per) },
+        (_, i) => ({
+          _id: `id-${start + i}`,
+          title: `Item ${start + i}`,
+          price: 1,
+          imageUrls: [],
+        }),
+      );
+      return Promise.resolve({
+        items,
+        total,
+        page,
+        limit: per,
+        hasMore: page * per < total,
+      });
+    });
+
+    render(<BrowsePage />);
+
+    // Wait for first page to render items
+    await waitFor(() => expect(itemService.getItems).toHaveBeenCalled());
+
+    // Should render item from page 1
+    expect(await screen.findByText(/Item 1/i)).toBeInTheDocument();
+
+    // Click page 2 in pagination
+    const page2 = await screen.findByRole('button', { name: '2' });
+    fireEvent.click(page2);
+
+    // Wait for second page load
+    await waitFor(() =>
+      expect(itemService.getItems).toHaveBeenCalledWith(
+        2,
+        expect.any(Number),
+        expect.any(Object),
+      ),
+    );
+
+    // New item from page 2 should be rendered
+    expect(await screen.findByText(/Item 10/i)).toBeInTheDocument();
+  });
+});

--- a/tests/integration/app/page.test.js
+++ b/tests/integration/app/page.test.js
@@ -7,7 +7,7 @@ import {
 } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import BrowsePage from '@/app/page';
-import { getItems, filterItems } from '@/services/itemService';
+import { getItems } from '@/services/itemService';
 
 // Mock Next.js Link component
 jest.mock('next/link', () => {
@@ -25,7 +25,6 @@ jest.mock('next/link', () => {
 // Mock itemService functions
 jest.mock('@/services/itemService', () => ({
   getItems: jest.fn(),
-  filterItems: jest.fn(),
 }));
 
 // Mock FilterBar component
@@ -99,7 +98,6 @@ describe('BrowsePage', () => {
 
   beforeEach(() => {
     getItems.mockResolvedValue(mockItemsResponse);
-    filterItems.mockResolvedValue(mockItemsResponse);
   });
 
   afterEach(() => {
@@ -216,7 +214,9 @@ describe('BrowsePage', () => {
       const filteredResponse = {
         items: [mockItems[0]], // Only one item
       };
-      filterItems.mockResolvedValue(filteredResponse);
+      // Ensure initial load returns full list, then filter returns smaller set
+      getItems.mockResolvedValueOnce(mockItemsResponse);
+      getItems.mockResolvedValueOnce(filteredResponse);
 
       await act(async () => {
         render(<BrowsePage />);
@@ -233,9 +233,13 @@ describe('BrowsePage', () => {
         fireEvent.click(filterButton);
       });
 
-      // Should call filterItems
+      // Should call getItems for the filtered request (page reset to 1)
       await waitFor(() => {
-        expect(filterItems).toHaveBeenCalledWith({ category: 'clothing' });
+        expect(getItems).toHaveBeenCalledWith(
+          expect.any(Number),
+          expect.any(Number),
+          expect.objectContaining({ category: 'clothing' }),
+        );
       });
 
       // Should update filtered items
@@ -245,7 +249,7 @@ describe('BrowsePage', () => {
     });
 
     test('sets loading state during filter changes', async () => {
-      filterItems.mockImplementation(
+      getItems.mockImplementation(
         () =>
           new Promise((resolve) =>
             setTimeout(() => resolve({ items: [mockItems[0]] }), 100),
@@ -297,7 +301,7 @@ describe('BrowsePage', () => {
       });
 
       await waitFor(() => {
-        expect(filterItems).toHaveBeenCalled();
+        expect(getItems).toHaveBeenCalled();
       });
 
       // Then clear filters
@@ -410,8 +414,8 @@ describe('BrowsePage', () => {
         expect(screen.getByTestId('items-length')).toHaveTextContent('3');
       });
 
-      // Set up error for subsequent filterItems calls
-      filterItems.mockRejectedValue(new Error('Filter Error'));
+      // Set up error for subsequent filtered getItems calls
+      getItems.mockRejectedValue(new Error('Filter Error'));
       const consoleSpy = jest
         .spyOn(console, 'error')
         .mockImplementation(() => {});
@@ -423,7 +427,7 @@ describe('BrowsePage', () => {
 
         // Wait for the async operation to attempt
         await waitFor(() => {
-          expect(filterItems).toHaveBeenCalled();
+          expect(getItems).toHaveBeenCalled();
         });
       });
 
@@ -451,7 +455,8 @@ describe('BrowsePage', () => {
       });
 
       // After filtering, filteredItems changes but original items remain
-      filterItems.mockResolvedValue({ items: [mockItems[0]] });
+      // Mock getItems to return filtered set on next call
+      getItems.mockResolvedValueOnce({ items: [mockItems[0]] });
 
       await act(async () => {
         const filterButton = screen.getByTestId('trigger-filter-change');
@@ -463,6 +468,7 @@ describe('BrowsePage', () => {
       });
 
       // Clear filters should restore to original items
+      getItems.mockResolvedValueOnce({ items: mockItems });
       await act(async () => {
         const clearButton = screen.getByTestId('clear-filters');
         fireEvent.click(clearButton);

--- a/tests/unit/app/api/items/[id]/route.test.js
+++ b/tests/unit/app/api/items/[id]/route.test.js
@@ -34,6 +34,15 @@ describe('GET /api/items/:id', () => {
     getDb.mockResolvedValue(mockDb);
   });
 
+  // Silence expected console.error from handler when tests simulate DB errors
+  let consoleErrorSpy;
+  beforeAll(() => {
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+  afterAll(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
   afterEach(() => {
     jest.clearAllMocks();
   });

--- a/tests/unit/app/api/items/route.test.js
+++ b/tests/unit/app/api/items/route.test.js
@@ -43,11 +43,15 @@ describe('GET /api/items', () => {
     mockCollection = {
       find: jest.fn(() => ({
         sort: jest.fn(() => ({
-          limit: jest.fn(() => ({
-            toArray: jest.fn().mockResolvedValue(mockItems),
+          skip: jest.fn(() => ({
+            limit: jest.fn(() => ({
+              toArray: jest.fn().mockResolvedValue(mockItems),
+            })),
           })),
         })),
       })),
+      // New pagination behavior uses countDocuments
+      countDocuments: jest.fn().mockResolvedValue(mockItems.length),
     };
 
     mockDb = {
@@ -161,8 +165,10 @@ describe('GET /api/items', () => {
   it('should sort by newest (default)', async () => {
     const request = new Request('http://localhost:3000/api/items');
     const mockSort = jest.fn(() => ({
-      limit: jest.fn(() => ({
-        toArray: jest.fn().mockResolvedValue(mockItems),
+      skip: jest.fn(() => ({
+        limit: jest.fn(() => ({
+          toArray: jest.fn().mockResolvedValue(mockItems),
+        })),
       })),
     }));
 
@@ -178,8 +184,10 @@ describe('GET /api/items', () => {
       'http://localhost:3000/api/items?sortBy=oldest',
     );
     const mockSort = jest.fn(() => ({
-      limit: jest.fn(() => ({
-        toArray: jest.fn().mockResolvedValue(mockItems),
+      skip: jest.fn(() => ({
+        limit: jest.fn(() => ({
+          toArray: jest.fn().mockResolvedValue(mockItems),
+        })),
       })),
     }));
 
@@ -195,8 +203,10 @@ describe('GET /api/items', () => {
       'http://localhost:3000/api/items?sortBy=price-low',
     );
     const mockSort = jest.fn(() => ({
-      limit: jest.fn(() => ({
-        toArray: jest.fn().mockResolvedValue(mockItems),
+      skip: jest.fn(() => ({
+        limit: jest.fn(() => ({
+          toArray: jest.fn().mockResolvedValue(mockItems),
+        })),
       })),
     }));
 
@@ -212,8 +222,10 @@ describe('GET /api/items', () => {
       'http://localhost:3000/api/items?sortBy=price-high',
     );
     const mockSort = jest.fn(() => ({
-      limit: jest.fn(() => ({
-        toArray: jest.fn().mockResolvedValue(mockItems),
+      skip: jest.fn(() => ({
+        limit: jest.fn(() => ({
+          toArray: jest.fn().mockResolvedValue(mockItems),
+        })),
       })),
     }));
 
@@ -231,7 +243,7 @@ describe('GET /api/items', () => {
     }));
 
     mockCollection.find.mockReturnValue({
-      sort: jest.fn(() => ({ limit: mockLimit })),
+      sort: jest.fn(() => ({ skip: jest.fn(() => ({ limit: mockLimit })) })),
     });
 
     await GET(request);
@@ -246,12 +258,12 @@ describe('GET /api/items', () => {
     }));
 
     mockCollection.find.mockReturnValue({
-      sort: jest.fn(() => ({ limit: mockLimit })),
+      sort: jest.fn(() => ({ skip: jest.fn(() => ({ limit: mockLimit })) })),
     });
 
     await GET(request);
 
-    expect(mockLimit).toHaveBeenCalledWith(48);
+    expect(mockLimit).toHaveBeenCalledWith(12);
   });
 
   it('should combine multiple filters', async () => {

--- a/tests/unit/app/api/transactions/create/route.test.js
+++ b/tests/unit/app/api/transactions/create/route.test.js
@@ -73,6 +73,15 @@ describe('POST /api/transactions/create', () => {
     jest.clearAllMocks();
   });
 
+  // Silence expected console.error logs from the route when simulating failures
+  let consoleErrorSpy;
+  beforeAll(() => {
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+  afterAll(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
   it('should create a transaction successfully', async () => {
     mockCollection.findOneAndUpdate.mockResolvedValue({
       value: {

--- a/tests/unit/components/ItemCard.test.js
+++ b/tests/unit/components/ItemCard.test.js
@@ -190,15 +190,8 @@ describe('ItemCard Component', () => {
       const card = screen.getByText('Baby Onesie 6M').closest('div');
       fireEvent.click(card);
 
-      // Ensure some debug logging occurred
-      expect(console.log).toHaveBeenCalled();
-
-      // Match the actual debug logs from ItemCard
-      expect(console.log).toHaveBeenCalledWith('=== ITEM DEBUG ===');
-      expect(console.log).toHaveBeenCalledWith(
-        'Full item object:',
-        expect.objectContaining({ id: '123' }),
-      );
+      // Verify navigation still occurs when the card is clicked
+      expect(mockPush).toHaveBeenCalledWith('/Items/123');
     });
   });
 

--- a/tests/unit/components/ItemGrid.test.js
+++ b/tests/unit/components/ItemGrid.test.js
@@ -1,10 +1,4 @@
-import {
-  render,
-  screen,
-  fireEvent,
-  waitFor,
-  act,
-} from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 // user-event not required; use fireEvent + waitFor to handle async updates
 import ItemGrid from '@/components/ItemGrid/ItemGrid';
 
@@ -163,194 +157,9 @@ describe('ItemGrid Component', () => {
     });
   });
 
-  // ===== LOAD MORE FUNCTIONALITY =====
-  describe('load more functionality', () => {
-    test('shows load more button when hasMore is true and onLoadMore provided', () => {
-      render(
-        <ItemGrid
-          items={mockItems}
-          hasMore={true}
-          onLoadMore={mockOnLoadMore}
-        />,
-      );
-
-      expect(screen.getByText('Load More Items')).toBeInTheDocument();
-    });
-
-    test('does not show load more button when hasMore is false', () => {
-      render(
-        <ItemGrid
-          items={mockItems}
-          hasMore={false}
-          onLoadMore={mockOnLoadMore}
-        />,
-      );
-
-      expect(screen.queryByText('Load More Items')).not.toBeInTheDocument();
-    });
-
-    test('does not show load more button when onLoadMore not provided', () => {
-      render(<ItemGrid items={mockItems} hasMore={true} />);
-
-      expect(screen.getByText('Load More Items')).toBeInTheDocument();
-    });
-
-    test('calls onLoadMore when load more button clicked', async () => {
-      render(
-        <ItemGrid
-          items={mockItems}
-          hasMore={true}
-          onLoadMore={mockOnLoadMore}
-        />,
-      );
-
-      const loadMoreButton = screen.getByText('Load More Items');
-      await act(async () => {
-        fireEvent.click(loadMoreButton);
-        await Promise.resolve();
-      });
-      await waitFor(() => {
-        expect(mockOnLoadMore).toHaveBeenCalledTimes(1);
-      });
-    });
-
-    test('shows loading state during load more operation', async () => {
-      let resolveLoadMore;
-      const slowLoadMore = jest.fn(() => {
-        return new Promise((resolve) => {
-          resolveLoadMore = resolve;
-        });
-      });
-
-      render(
-        <ItemGrid items={mockItems} hasMore={true} onLoadMore={slowLoadMore} />,
-      );
-
-      const loadMoreButton = screen.getByText('Load More Items');
-      await act(async () => {
-        fireEvent.click(loadMoreButton);
-        await Promise.resolve();
-      });
-
-      // Should show loading state
-      expect(screen.getByText('Loading more...')).toBeInTheDocument();
-      expect(screen.queryByText('Load More Items')).not.toBeInTheDocument();
-
-      // Should show loading skeletons
-      const loadingSkeletons = document.querySelectorAll(
-        '[class*="skeletonCard"]',
-      );
-      expect(loadingSkeletons).toHaveLength(4);
-
-      // Resolve the promise
-      resolveLoadMore();
-      await waitFor(() => {
-        expect(screen.getByText('Load More Items')).toBeInTheDocument();
-      });
-    });
-
-    test('disables button during loading', async () => {
-      let resolveLoadMore;
-      const slowLoadMore = jest.fn(() => {
-        return new Promise((resolve) => {
-          resolveLoadMore = resolve;
-        });
-      });
-
-      render(
-        <ItemGrid items={mockItems} hasMore={true} onLoadMore={slowLoadMore} />,
-      );
-
-      const loadMoreButton = screen.getByText('Load More Items');
-      fireEvent.click(loadMoreButton);
-
-      // Button should be disabled
-      await waitFor(() => {
-        const disabledButton = screen.getByRole('button', {
-          name: /loading more/i,
-        });
-        expect(disabledButton).toBeDisabled();
-      });
-
-      resolveLoadMore();
-    });
-
-    test('prevents multiple simultaneous load more calls', async () => {
-      let resolveLoadMore;
-      const slowLoadMore = jest.fn(() => {
-        return new Promise((resolve) => {
-          resolveLoadMore = resolve;
-        });
-      });
-
-      render(
-        <ItemGrid items={mockItems} hasMore={true} onLoadMore={slowLoadMore} />,
-      );
-
-      const loadMoreButton = screen.getByText('Load More Items');
-
-      // Click multiple times but allow each click to process so subsequent clicks
-      // won't trigger while loading. This mirrors real user behavior.
-      await act(async () => {
-        fireEvent.click(loadMoreButton);
-        await Promise.resolve();
-        fireEvent.click(loadMoreButton);
-        await Promise.resolve();
-        fireEvent.click(loadMoreButton);
-        await Promise.resolve();
-      });
-
-      // Should only call once
-      await waitFor(() => {
-        expect(slowLoadMore).toHaveBeenCalledTimes(1);
-      });
-
-      resolveLoadMore();
-    });
-
-    test('handles load more error gracefully', async () => {
-      const consoleSpy = jest
-        .spyOn(console, 'error')
-        .mockImplementation(() => {});
-      const failingLoadMore = jest.fn(() => {
-        throw new Error('Load failed');
-      });
-
-      render(
-        <ItemGrid
-          items={mockItems}
-          hasMore={true}
-          onLoadMore={failingLoadMore}
-        />,
-      );
-
-      const loadMoreButton = screen.getByText('Load More Items');
-      fireEvent.click(loadMoreButton);
-
-      // Should reset loading state even after error
-      await waitFor(() => {
-        expect(screen.getByText('Load More Items')).toBeInTheDocument();
-      });
-
-      // Should not be loading anymore
-      expect(screen.queryByText('Loading more...')).not.toBeInTheDocument();
-      consoleSpy.mockRestore();
-    });
-
-    test('does not call load more when hasMore is false', () => {
-      render(
-        <ItemGrid
-          items={mockItems}
-          hasMore={false}
-          onLoadMore={mockOnLoadMore}
-        />,
-      );
-
-      // Should not show button, so no way to trigger call
-      expect(screen.queryByText('Load More Items')).not.toBeInTheDocument();
-      expect(mockOnLoadMore).not.toHaveBeenCalled();
-    });
-  });
+  // Load-more behavior removed from component; tests related to that feature
+  // were intentionally deleted because UI no longer includes a "Load More"
+  // button. The component now relies on pagination controls elsewhere.
 
   // ===== END MESSAGE =====
   describe('end message', () => {
@@ -403,7 +212,8 @@ describe('ItemGrid Component', () => {
       );
 
       expect(screen.getByTestId('item-card-1')).toBeInTheDocument();
-      expect(screen.getByText('Load More Items')).toBeInTheDocument();
+      // Load More button removed from UI; verify it's not present
+      expect(screen.queryByText('Load More Items')).not.toBeInTheDocument();
       expect(
         screen.queryByText('You have reached the end! 🎉'),
       ).not.toBeInTheDocument();
@@ -464,69 +274,21 @@ describe('ItemGrid Component', () => {
       expect(screen.getByTestId('item-card-2')).toBeInTheDocument();
     });
 
-    test('handles onLoadMore that returns non-promise', async () => {
+    test('handles onLoadMore prop gracefully when provided (no UI)', () => {
       const syncLoadMore = jest.fn(() => 'not a promise');
 
       render(
         <ItemGrid items={mockItems} hasMore={true} onLoadMore={syncLoadMore} />,
       );
 
-      const loadMoreButton = screen.getByText('Load More Items');
-      await act(async () => {
-        fireEvent.click(loadMoreButton);
-      });
-
-      // Should handle gracefully
-      expect(syncLoadMore).toHaveBeenCalledTimes(1);
-
-      // Should reset loading state
-      await waitFor(() => {
-        expect(screen.getByText('Load More Items')).toBeInTheDocument();
-      });
+      // Component no longer exposes a Load More button — ensure nothing called
+      expect(screen.queryByText('Load More Items')).not.toBeInTheDocument();
+      expect(syncLoadMore).not.toHaveBeenCalled();
     });
   });
 
   // ===== ACCESSIBILITY =====
   describe('accessibility', () => {
-    test('load more button is accessible', () => {
-      render(
-        <ItemGrid
-          items={mockItems}
-          hasMore={true}
-          onLoadMore={mockOnLoadMore}
-        />,
-      );
-
-      const button = screen.getByRole('button', { name: /load more items/i });
-      expect(button).toBeInTheDocument();
-    });
-
-    test('disabled load more button is accessible', async () => {
-      let resolveLoadMore;
-      const slowLoadMore = jest.fn(() => {
-        return new Promise((resolve) => {
-          resolveLoadMore = resolve;
-        });
-      });
-
-      render(
-        <ItemGrid items={mockItems} hasMore={true} onLoadMore={slowLoadMore} />,
-      );
-
-      const button = screen.getByText('Load More Items');
-      await act(async () => {
-        fireEvent.click(button);
-      });
-
-      await waitFor(() => {
-        const disabledButton = screen.getByRole('button');
-        expect(disabledButton).toBeDisabled();
-        expect(disabledButton).toHaveAttribute('disabled');
-      });
-
-      resolveLoadMore();
-    });
-
     test('empty state has proper heading structure', () => {
       render(<ItemGrid items={[]} loading={false} />);
 

--- a/tests/unit/components/Pagination.test.js
+++ b/tests/unit/components/Pagination.test.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import Pagination from '@/components/Pagination/Pagination';
+
+describe('Pagination component', () => {
+  test('renders pagination and calls onPageChange', () => {
+    const onPageChange = jest.fn();
+    render(
+      <Pagination
+        page={2}
+        total={90}
+        limit={9}
+        onPageChange={onPageChange}
+        maxPagesToShow={5}
+      />,
+    );
+
+    // should show Prev/Next and numbered pages
+    expect(screen.getByRole('button', { name: /Prev/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Next/i })).toBeInTheDocument();
+
+    // page 2 button should be present and aria-current
+    const btn2 = screen.getByRole('button', { name: '2' });
+    expect(btn2).toBeInTheDocument();
+    expect(btn2).toHaveAttribute('aria-current', 'page');
+
+    // click another page
+    const btn3 = screen.getByRole('button', { name: '3' });
+    fireEvent.click(btn3);
+    expect(onPageChange).toHaveBeenCalledWith(3);
+
+    // click Prev
+    const prev = screen.getByRole('button', { name: /Prev/i });
+    fireEvent.click(prev);
+    expect(onPageChange).toHaveBeenCalledWith(1);
+
+    // click Next
+    const next = screen.getByRole('button', { name: /Next/i });
+    fireEvent.click(next);
+    expect(onPageChange).toHaveBeenCalledWith(3);
+  });
+
+  test('does not render when only one page', () => {
+    const onPageChange = jest.fn();
+    const { container } = render(
+      <Pagination page={1} total={5} limit={10} onPageChange={onPageChange} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/tests/unit/components/PurchaseModal.test.js
+++ b/tests/unit/components/PurchaseModal.test.js
@@ -47,6 +47,19 @@ describe('PurchaseModal Component', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     fetch.mockClear();
+    // Silence expected error logs from the component during negative tests
+    if (!global.consoleErrorSpy) {
+      global.consoleErrorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+    }
+  });
+
+  afterEach(() => {
+    if (global.consoleErrorSpy) {
+      global.consoleErrorSpy.mockRestore();
+      delete global.consoleErrorSpy;
+    }
   });
 
   // ========================================


### PR DESCRIPTION
This pull request introduces paginated browsing for items, refactors the item grid to support numbered pagination instead of infinite "Load More", and improves viewport-based item-per-page calculation. It also includes related style changes, test updates, and a new pagination component. These changes make the browsing experience more scalable and user-friendly, especially for large datasets.

### Pagination and Data Fetching Improvements

* Added paginated API support: The backend (`src/app/api/items/route.js`) now accepts `page` and `limit` parameters, returns pagination metadata (`total`, `page`, `limit`, `hasMore`), and skips items accordingly for efficient page-based browsing. 
* Introduced a custom hook `useItemsPerPage` to dynamically determine items per page based on viewport size, ensuring a consistent grid layout across devices.
* Added a new `Pagination` component (`src/components/Pagination/Pagination.js` and `Pagination.module.css`) to display numbered pagination controls, replacing the previous "Load More" infinite scroll approach.

### UI and Grid Layout Changes

* Refactored `ItemGrid` to remove infinite "Load More" logic and button, ensuring items are displayed in a fixed 3-column grid for all screen sizes as per requirements. 
* Updated the main page (`src/app/page.js`) to manage pagination state, fetch items for the selected page, and render the new pagination controls.

### Testing and Mocks

* Added integration tests for pagination in `BrowsePage`, mocking service calls and verifying correct page navigation and rendering.
* Updated mocks for `next/image` to safely forward only valid DOM props, preventing React warnings in Jest tests. 
* Cleaned up and silenced noisy test output in server action tests by mocking `console.error`.

### Minor Fixes and Cleanups

* Improved error handling in `ItemDetail` by ignoring JSON parse errors when parsing error responses.
* Removed unused box-shadow from item detail button styles for cleaner UI.
* Removed unused `filterItems` references from tests and main page code, consolidating filtering into the paginated API. 